### PR TITLE
Add recent manga page with reranking based on tag word2vec

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -11,6 +11,7 @@ Set up a `.env` file with the following variables:
 
 ```bash
 VITE_STATIC_HOST=https://storage.googleapis.com/manga-recsys
+VITE_CACHE_BUCKET=manga-recsys-cache
 # NOTE: http://localhost:4000 for local development with docker compose
 ```
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "localforage": "^1.10.0",
         "lodash-es": "^4.17.21",
         "luxon": "^3.2.1",
+        "mathjs": "^11.5.0",
         "prismjs": "^1.29.0",
         "tabulator-tables": "^5.4.3",
         "tippy.js": "^6.3.7",
@@ -32,6 +33,17 @@
         "remark-toc": "^8.0.1",
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -987,6 +999,18 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
+    "node_modules/complex.js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
+      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -1034,6 +1058,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -1132,6 +1161,11 @@
         "@esbuild/win32-x64": "0.16.7"
       }
     },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+    },
     "node_modules/esm-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
@@ -1161,6 +1195,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
       "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
+    },
+    "node_modules/fraction.js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1551,6 +1597,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -1659,6 +1710,28 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.5.0.tgz",
+      "integrity": "sha512-vJ/+SqWtxjW6/aeDRt8xL3TlOVKqwN15BIyTGVqGbIWuiqgY4SxZ0yLuna82YH9CB757iFP7uJ4m3KvVBX7Qcg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "complex.js": "^2.1.1",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.2.0",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.1.0"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/mdast-util-to-string": {
@@ -1989,6 +2062,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/rehype-autolink-headings": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-6.1.1.tgz",
@@ -2153,6 +2231,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/set-cookie-parser": {
       "version": "2.5.1",
@@ -2353,6 +2436,11 @@
       "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "peer": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
@@ -2393,6 +2481,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.0.tgz",
+      "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/undici": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google-cloud/storage": "^6.9.0",
         "fuse.js": "^6.6.2",
+        "localforage": "^1.10.0",
         "lodash-es": "^4.17.21",
         "luxon": "^3.2.1",
         "prismjs": "^1.29.0",
@@ -1442,6 +1443,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1601,6 +1607,22 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/lodash-es": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,8 +8,10 @@
       "name": "app",
       "version": "0.10.0",
       "dependencies": {
+        "@google-cloud/storage": "^6.9.0",
         "fuse.js": "^6.6.2",
         "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
         "prismjs": "^1.29.0",
         "tabulator-tables": "^5.4.3",
         "tippy.js": "^6.3.7",
@@ -395,6 +397,61 @@
         "node": ">=12"
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
+      "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
+      "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.9.0.tgz",
+      "integrity": "sha512-0mn9DUe3dtyTWLsWLplQP3gzPolJ5kD4PwHuzeD3ye0SAQ+oFfDbT8d+vNZxqyvddL2c6uNP72TKETN2PQxDKg==",
+      "dependencies": {
+        "@google-cloud/paginator": "^3.0.7",
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "compressible": "^2.0.12",
+        "duplexify": "^4.0.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "gaxios": "^5.0.0",
+        "google-auth-library": "^8.0.1",
+        "mime": "^3.0.0",
+        "mime-types": "^2.0.8",
+        "p-limit": "^3.0.1",
+        "retry-request": "^5.0.0",
+        "teeny-request": "^8.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
@@ -671,6 +728,14 @@
         "vite": "^4.0.0"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
@@ -739,6 +804,17 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -751,6 +827,33 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/bail": {
@@ -769,6 +872,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcp-47-match": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
@@ -777,6 +899,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/boolbase": {
@@ -793,6 +923,11 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -857,6 +992,17 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "peer": true
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -876,7 +1022,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -916,6 +1061,38 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
     },
     "node_modules/esbuild": {
       "version": "0.16.7",
@@ -966,11 +1143,23 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1004,6 +1193,32 @@
       "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.2.tgz",
+      "integrity": "sha512-TjtV2AJOZoMQqRYoy5eM8cCQogYwazWNYLQ72QB0kwa6vHHruYkGmhhyrlzbmgNHK1dNnuP2WSH81urfzyN2Og==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.2.0.tgz",
+      "integrity": "sha512-aFhhvvNycky2QyhG+dcfEdHBF0FRbYcf39s6WNHUDysKSrbJ5vuFbjydxBcmewtXeV248GP8dWT3ByPNxsyHCw==",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/github-slugger": {
@@ -1042,6 +1257,52 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
+    },
+    "node_modules/google-auth-library": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.7.0.tgz",
+      "integrity": "sha512-1M0NG5VDIvJZEnstHbRdckLZESoJwguinwN8Dhae0j2ZKIQFIV63zxm6Fo6nM4xkgqUr2bbMtV5Dgo+Hy6oo0Q==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1156,6 +1417,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1169,8 +1455,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-buffer": {
       "version": "2.0.5",
@@ -1249,6 +1534,44 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/katex": {
       "version": "0.15.6",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.15.6.tgz",
@@ -1284,6 +1607,25 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.27.0",
@@ -1375,12 +1717,30 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -1416,8 +1776,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -1429,6 +1788,33 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/not": {
@@ -1453,9 +1839,22 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-parse": {
@@ -1553,6 +1952,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rehype-autolink-headings": {
@@ -1653,6 +2065,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
+      "integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.4.tgz",
@@ -1680,6 +2112,25 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/set-cookie-parser": {
       "version": "2.5.1",
@@ -1750,6 +2201,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -1758,6 +2222,19 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -1796,6 +2273,29 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.4.3.tgz",
       "integrity": "sha512-XnQcfwd2LzHWKAo8ZzUVglKaQnzn3wZwH48ouYr1dDbfUcQiU1ESJjVhmVxPMr9tf0oDcV6qPViEHinAi/tqbw=="
+    },
+    "node_modules/teeny-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.2.tgz",
+      "integrity": "sha512-34pe0a4zASseXZCKdeTiIZqSKA8ETHb1EwItZr01PAR3CLPojeAKgSjzeNS4373gi59hNulyDrPKEbh2zO9sCg==",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/terser": {
       "version": "5.16.1",
@@ -1857,6 +2357,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trough": {
       "version": "2.1.0",
@@ -1951,11 +2456,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2131,11 +2640,40 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,7 @@
     "localforage": "^1.10.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.2.1",
+    "mathjs": "^11.5.0",
     "prismjs": "^1.29.0",
     "tabulator-tables": "^5.4.3",
     "tippy.js": "^6.3.7",

--- a/app/package.json
+++ b/app/package.json
@@ -26,8 +26,10 @@
   },
   "type": "module",
   "dependencies": {
+    "@google-cloud/storage": "^6.9.0",
     "fuse.js": "^6.6.2",
     "lodash-es": "^4.17.21",
+    "luxon": "^3.2.1",
     "prismjs": "^1.29.0",
     "tabulator-tables": "^5.4.3",
     "tippy.js": "^6.3.7",

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@google-cloud/storage": "^6.9.0",
     "fuse.js": "^6.6.2",
+    "localforage": "^1.10.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.2.1",
     "prismjs": "^1.29.0",

--- a/app/src/lib/PersonalLibraryChart.svelte
+++ b/app/src/lib/PersonalLibraryChart.svelte
@@ -1,0 +1,68 @@
+<script>
+  // a bar chart that shows how far the personal library is from various tags
+  import { onMount } from "svelte";
+  import {
+    library_edits,
+    getLibrary,
+    fetchTagWordVectors,
+    computeMeanVector,
+    computeTagVector,
+    computeVectorSimilarity
+  } from "$lib/personalization.js";
+  import { browser } from "$app/environment";
+  import Plot from "$lib/Plot.svelte";
+
+  export let data = [];
+  let tags = [["Romance"], ["Drama"], ["Adventure"], ["Fantasy"], ["Sports"]];
+  let word_vectors = new Map();
+  onMount(async () => {
+    data = await getLibrary();
+    word_vectors = await fetchTagWordVectors();
+  });
+
+  $: browser &&
+    $library_edits &&
+    getLibrary().then((library) => {
+      data = library;
+      $library_edits = 0;
+    });
+  function computePersonalVector(data, word_vectors) {
+    if (data.length == 0) return [];
+    if (word_vectors.size == 0) return [];
+    let manga_vectors = data.map((row) =>
+      computeTagVector(
+        row.tags.map((t) => t.name),
+        word_vectors
+      )
+    );
+    return computeMeanVector(manga_vectors);
+  }
+  $: personal_vector = computePersonalVector(data, word_vectors);
+  $: tag_vectors =
+    word_vectors.size > 0 ? tags.map((tag) => computeTagVector(tag, word_vectors)) : [];
+  $: similarities =
+    personal_vector.length && tag_vectors.length
+      ? tag_vectors.map((tag_vector) => computeVectorSimilarity(personal_vector, tag_vector))
+      : [];
+
+  function transform(data) {
+    return [
+      {
+        x: tags.map((t) => t.join(", ")),
+        y: data,
+        type: "bar"
+      }
+    ];
+  }
+  $: layout = {
+    title: "Personal Library",
+    xaxis: {
+      title: "Tag"
+    },
+    yaxis: {
+      title: "Similarity"
+    }
+  };
+</script>
+
+<Plot data={similarities} {transform} {layout} />

--- a/app/src/lib/PersonalLibraryTable.svelte
+++ b/app/src/lib/PersonalLibraryTable.svelte
@@ -1,0 +1,94 @@
+<script>
+  import Table from "$lib/Table.svelte";
+  import { tippyMangaInfo, destroyTippy } from "$lib/tabulator.js";
+  import "tippy.js/dist/tippy.css";
+  import { library_edits, getLibrary, removeMangaFromLibrary } from "$lib/personalization.js";
+  import { browser } from "$app/environment";
+  import { onMount } from "svelte";
+  import { DateTime } from "luxon";
+
+  export let data = [];
+  export let paginationSize = 10;
+
+  let table;
+
+  onMount(() => {
+    $library_edits += 1;
+  });
+
+  $: browser &&
+    $library_edits &&
+    getLibrary().then((library) => {
+      data = library;
+      $library_edits = 0;
+    });
+
+  $: options = {
+    pagination: true,
+    paginationSize: paginationSize,
+    paginationCounter: "rows",
+    columns: [
+      {
+        field: "added",
+        formatter: (cell) => {
+          const rowData = cell.getRow().getData();
+          // format using luxon and give relative time
+          return DateTime.fromISO(rowData.added).toRelative();
+        }
+      },
+      { field: "id", visible: false },
+      {
+        field: "name",
+        headerFilter: true,
+        // no-op function since we're going to filter the data ourselves
+        headerFilterFunc: () => true,
+        formatter: "link",
+        formatterParams: {
+          urlPrefix: "https://mangadex.org/manga/",
+          // get row from cell
+          label: (cell) => {
+            const rowData = cell.getRow().getData();
+            return rowData.name || rowData.id;
+          },
+          urlField: "id",
+          target: "_blank"
+        },
+        width: 300
+      },
+      {
+        field: "tags",
+        // custom formatter to flatten object
+        formatter: (cell) => {
+          const rowData = cell.getRow().getData();
+          return rowData.tags.map((tag) => tag.name).join(", ");
+        },
+        // also set max width
+        width: 200
+      },
+      {
+        field: "remove",
+        title: "remove",
+        formatter: "tickCross",
+        hozAlign: "center",
+        editor: true
+      }
+    ]
+  };
+
+  $: table &&
+    table.on("cellEdited", async (cell) => {
+      const rowData = cell.getRow().getData();
+      await removeMangaFromLibrary(rowData.id);
+      // also, we need to trigger the component to update
+      $library_edits += 1;
+    });
+  // when hovering over a row, show the tooltip with the group info
+  $: table && table.on("rowMouseOver", (_, row) => tippyMangaInfo(row, {}, "id"));
+  $: table && table.on("rowMouseOut", (_, row) => destroyTippy(row));
+</script>
+
+{#if data.length}
+  <Table {data} {options} bind:table />
+{:else}
+  <p>No manga in personal library.</p>
+{/if}

--- a/app/src/lib/PersonalLibraryTable.svelte
+++ b/app/src/lib/PersonalLibraryTable.svelte
@@ -52,8 +52,7 @@
           },
           urlField: "id",
           target: "_blank"
-        },
-        width: 300
+        }
       },
       {
         field: "tags",
@@ -63,7 +62,7 @@
           return rowData.tags.map((tag) => tag.name).join(", ");
         },
         // also set max width
-        width: 200
+        width: 100
       },
       {
         field: "remove",

--- a/app/src/lib/Plot.svelte
+++ b/app/src/lib/Plot.svelte
@@ -7,22 +7,27 @@
 
   function onLoad() {
     console.log(transform(data));
-    Plotly.newPlot(
-      plotElement,
-      transform(data),
-      merge(
-        {
-          margin: {
-            l: 50,
-            r: 0,
-            b: 50
-          }
-        },
-        layout
-      ),
-      { responsive: true }
-    );
+    try {
+      Plotly.newPlot(
+        plotElement,
+        transform(data),
+        merge(
+          {
+            margin: {
+              l: 50,
+              r: 0,
+              b: 50
+            }
+          },
+          layout
+        ),
+        { responsive: true }
+      );
+    } catch (e) {
+      console.log(e);
+    }
   }
+  $: plotElement && data && data.length && onLoad();
 </script>
 
 <svelte:head>

--- a/app/src/lib/Plot.svelte
+++ b/app/src/lib/Plot.svelte
@@ -1,0 +1,34 @@
+<script>
+  import { merge } from "lodash-es";
+  export let data;
+  export let transform = (res) => res;
+  export let layout = {};
+  let plotElement;
+
+  function onLoad() {
+    console.log(transform(data));
+    Plotly.newPlot(
+      plotElement,
+      transform(data),
+      merge(
+        {
+          margin: {
+            l: 50,
+            r: 0,
+            b: 50
+          }
+        },
+        layout
+      ),
+      { responsive: true }
+    );
+  }
+</script>
+
+<svelte:head>
+  {#if plotElement && data && data.length}
+    <script src="https://cdn.plot.ly/plotly-2.16.1.min.js" on:load={onLoad}></script>
+  {/if}
+</svelte:head>
+
+<div bind:this={plotElement} />

--- a/app/src/lib/personalization.js
+++ b/app/src/lib/personalization.js
@@ -1,0 +1,34 @@
+// utilities for saving and loading personalization data via localforage
+
+import localforage from "localforage";
+import { writable } from "svelte/store";
+
+// store for signaling how many times something has been edited
+const library_edits = writable(0);
+
+const LIBRARY_KEY = "manga-library";
+
+async function getLibrary() {
+  return (await localforage.getItem(LIBRARY_KEY)) || [];
+}
+
+async function addMangaToLibrary(id, name, tags) {
+  let library = await getLibrary();
+  // the library is a list of objects with id, name, and tags
+  let ids = library.map((manga) => manga.id);
+  if (!ids.includes(id)) {
+    library.push({ id, name, tags, added: new Date().toISOString() });
+    await localforage.setItem(LIBRARY_KEY, library);
+  }
+}
+
+async function removeMangaFromLibrary(id) {
+  let library = await getLibrary();
+  let ids = library.map((manga) => manga.id);
+  if (ids.includes(id)) {
+    library = library.filter((manga) => manga.id !== id);
+    await localforage.setItem(LIBRARY_KEY, library);
+  }
+}
+
+export { library_edits, getLibrary, addMangaToLibrary, removeMangaFromLibrary };

--- a/app/src/lib/personalization.js
+++ b/app/src/lib/personalization.js
@@ -1,7 +1,7 @@
 // utilities for saving and loading personalization data via localforage
-
 import localforage from "localforage";
 import { writable } from "svelte/store";
+import { mean, dot, norm } from "mathjs";
 
 // store for signaling how many times something has been edited
 const library_edits = writable(0);
@@ -31,4 +31,38 @@ async function removeMangaFromLibrary(id) {
   }
 }
 
-export { library_edits, getLibrary, addMangaToLibrary, removeMangaFromLibrary };
+async function fetchTagWordVectors() {
+  let resp = await fetch("/api/v1/models/manga-tags-word2vec/word2vec.json?server=true");
+  let data = await resp.json();
+  return new Map(Object.entries(data["emb"]));
+}
+
+function computeMeanVector(vectors) {
+  return mean(vectors, 0);
+}
+
+function computeTagVector(tags, word_vectors) {
+  if (tags.length === 0) {
+    return [];
+  }
+  let vectors = tags.map((tag) => word_vectors.get(tag));
+  //   console.log(vectors);
+  return computeMeanVector(vectors);
+}
+
+function computeVectorSimilarity(v1, v2) {
+  // similarity using the cosine distance
+  let similarity = dot(v1, v2) / (norm(v1) * norm(v2));
+  return similarity;
+}
+
+export {
+  library_edits,
+  getLibrary,
+  addMangaToLibrary,
+  removeMangaFromLibrary,
+  fetchTagWordVectors,
+  computeMeanVector,
+  computeTagVector,
+  computeVectorSimilarity
+};

--- a/app/src/routes/+page.md
+++ b/app/src/routes/+page.md
@@ -10,5 +10,6 @@ Feel free to reach out with questions or comments on the MangaDex or Tachiyomi d
 - [manga](./manga)
   - [explore](./manga/explore)
   - [embedding plots](./manga/embedding-plots)
+  - [feed](./manga/feed)
 - [data](./data)
 - [openapi](./openapi)

--- a/app/src/routes/api/v1/feed/recent/+server.js
+++ b/app/src/routes/api/v1/feed/recent/+server.js
@@ -1,0 +1,55 @@
+/**
+ * This endpoint is the get the most recent manga from the
+ * api.mangadex.org/manga endpoint. We do our best to cache the last 500
+ * responses every 60 minutes on demand. Our caching logic will check the bucket
+ * for a timestamped item which we will use if it exists. We will serve the
+ * content as-is, will just come out of the bucket.
+ *
+ */
+import { Storage } from "@google-cloud/storage";
+import { error, json } from "@sveltejs/kit";
+
+const fetchMostRecentManga = async (fetch, limit = 100) => {
+  let url = `https://api.mangadex.org/manga?&order[updatedAt]=desc&limit=${limit}`;
+  let resp = await fetch(url);
+  return await resp.json();
+};
+
+export async function GET({ fetch }) {
+  const limit = 100;
+  // first lets check if we have a cached version of the response
+  // get a date string YYYY-MM-DDTHH:00 rounded to the current hour
+  let date = new Date();
+  date.setMinutes(0);
+  date.setSeconds(0);
+  date.setMilliseconds(0);
+  let dateStr = date.toISOString().slice(0, 16);
+  let prefix = `api/v1/feed/recent/${dateStr}.json`;
+  // get the storage bucket
+  const cacheBucket = import.meta.env.VITE_CACHE_BUCKET;
+  const storage = new Storage();
+
+  const bucket = storage.bucket(cacheBucket);
+  // check if we have a cached version of the response
+
+  let content = null;
+
+  try {
+    content = JSON.parse(await bucket.file(prefix).download());
+    console.log(`Serving cached content for ${prefix}`);
+  } catch (e) {
+    // the contents don't exist, so fetch it from mangadex and upload it into
+    // the bucket
+    let data = await fetchMostRecentManga(fetch, limit);
+    await bucket.file(prefix).save(JSON.stringify(data));
+    content = data;
+    console.log(`Fetched and cached content for ${prefix}`);
+  }
+
+  // check that the content is valid
+  if (content === null) {
+    return error(500, "Unable to fetch content");
+  }
+  // now serve the content
+  return json(content);
+}

--- a/app/src/routes/manga/+page.md
+++ b/app/src/routes/manga/+page.md
@@ -11,6 +11,8 @@ Note that this page may take some time to load.
 
 See the [manga embedding plots](/manga/embedding-plots) page for a visualization of the recommendations through the embedding space.
 
+See the [manga feed](/manga/feed) page for a feed of manga from MangaDex that have been re-ranked.
+
 ## notes
 
 ### table of contents

--- a/app/src/routes/manga/feed/+page.md
+++ b/app/src/routes/manga/feed/+page.md
@@ -29,7 +29,7 @@
 {/if}
 
 <style>
-  .personal {
+  /* .personal {
     display: grid;
     grid-template-columns: 1fr 1fr;
   }
@@ -38,5 +38,5 @@
       display: flex;
       flex-direction: column;
     }
-  }
+  } */
 </style>

--- a/app/src/routes/manga/feed/+page.md
+++ b/app/src/routes/manga/feed/+page.md
@@ -1,0 +1,13 @@
+<script>
+  import FeedTable from "./FeedTable.svelte";
+  export let data;
+</script>
+
+# manga feed
+
+{#if data.feed_data}
+
+  <div>
+    <FeedTable data={data.feed_data} />
+  </div>
+{/if}

--- a/app/src/routes/manga/feed/+page.md
+++ b/app/src/routes/manga/feed/+page.md
@@ -1,6 +1,7 @@
 <script>
   import FeedTable from "./FeedTable.svelte";
   import PersonalLibraryTable from "$lib/PersonalLibraryTable.svelte";
+  import PersonalLibraryChart from "$lib/PersonalLibraryChart.svelte";
 
   export let data;
 </script>
@@ -9,7 +10,14 @@
 
 ## personal library
 
+<div class="personal">
+<div>
 <PersonalLibraryTable paginationSize={10} />
+</div>
+<div>
+<PersonalLibraryChart />
+</div>
+</div>
 
 ## feed
 
@@ -19,3 +27,16 @@
     <FeedTable data={data.feed_data} />
   </div>
 {/if}
+
+<style>
+  .personal {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+  @media (max-width: 600px) {
+    .personal {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/app/src/routes/manga/feed/+page.md
+++ b/app/src/routes/manga/feed/+page.md
@@ -1,9 +1,17 @@
 <script>
   import FeedTable from "./FeedTable.svelte";
+  import PersonalLibraryTable from "$lib/PersonalLibraryTable.svelte";
+
   export let data;
 </script>
 
 # manga feed
+
+## personal library
+
+<PersonalLibraryTable paginationSize={10} />
+
+## feed
 
 {#if data.feed_data}
 

--- a/app/src/routes/manga/feed/+page.server.js
+++ b/app/src/routes/manga/feed/+page.server.js
@@ -1,0 +1,25 @@
+function preprocess(data) {
+  return data.map((row) => {
+    return {
+      updatedAt: row.attributes.updatedAt,
+      id: row.id,
+      originalLanguage: row.attributes.originalLanguage,
+      name: row.attributes.title.en,
+      latestUploadedChapter: row.attributes.latestUploadedChapter,
+      description: row.attributes.description.en,
+      tags: row.attributes.tags.map((tag) => ({
+        name: tag.attributes.name.en,
+        id: tag.attributes.group
+      })),
+      availableTranslatedLanguages: row.attributes.availableTranslatedLanguages
+    };
+  });
+}
+
+export async function load({ fetch }) {
+  let resp = await fetch(`/api/v1/feed/recent`);
+  let data = await resp.json();
+  return {
+    feed_data: preprocess(data.data)
+  };
+}

--- a/app/src/routes/manga/feed/FeedTable.svelte
+++ b/app/src/routes/manga/feed/FeedTable.svelte
@@ -1,0 +1,89 @@
+<script>
+  import Table from "$lib/Table.svelte";
+  import { destroyTippy } from "$lib/tabulator.js";
+  import tippy from "tippy.js";
+  import "tippy.js/dist/tippy.css";
+  import { DateTime } from "luxon";
+
+  export let data;
+
+  let table;
+
+  $: options = {
+    autoColumns: true,
+    pagination: true,
+    paginationSize: 50,
+    paginationCounter: "rows",
+    autoColumnsDefinitions: [
+      {
+        field: "updatedAt",
+        title: "updated",
+        formatter: (cell) => {
+          const rowData = cell.getRow().getData();
+          // format using luxon and give relative time
+          return DateTime.fromISO(rowData.updatedAt).toRelative();
+        }
+      },
+      {
+        field: "originalLanguage",
+        title: "lang"
+      },
+      { field: "id", visible: false },
+      {
+        field: "name",
+        headerFilter: true,
+        // no-op function since we're going to filter the data ourselves
+        headerFilterFunc: () => true,
+        formatter: "link",
+        formatterParams: {
+          urlPrefix: "https://mangadex.org/manga/",
+          // get row from cell
+          label: (cell) => {
+            const rowData = cell.getRow().getData();
+            return rowData.name || rowData.id;
+          },
+          urlField: "id",
+          target: "_blank"
+        },
+        width: 300
+      },
+      {
+        field: "latestUploadedChapter",
+        title: "chapter",
+        formatter: "link",
+        formatterParams: {
+          urlPrefix: "https://mangadex.org/chapter/",
+          label: (cell) => (cell.getValue() ? "link" : ""),
+          target: "_blank"
+        }
+      },
+      {
+        field: "tags",
+        // custom formatter to flatten object
+        formatter: (cell) => {
+          const rowData = cell.getRow().getData();
+          return rowData.tags.map((tag) => tag.name).join(", ");
+        },
+        // also set max width
+        width: 200
+      },
+      {
+        field: "availableTranslatedLanguages",
+        title: "translated"
+      },
+      {
+        field: "description",
+        visible: false
+      }
+    ]
+  };
+
+  // when hovering over a row, show the tooltip with the group info
+  $: table &&
+    table.on("rowMouseOver", (_, row) => {
+      tippy(row.getElement(), { content: row.getData().description });
+    });
+  $: table && table.on("rowMouseOut", (_, row) => destroyTippy(row));
+</script>
+
+<Table {data} {options} bind:table />

--- a/app/static/openapi/openapi.yaml
+++ b/app/static/openapi/openapi.yaml
@@ -87,3 +87,20 @@ paths:
     get:
       <<: *manga-tags-recommendations
       summary: manga tags network adjacency matrix with cosine distance recommendations
+  /api/v1/feed/recent:
+    get:
+      tags:
+        - feed
+      summary: fetch recent manga updates
+      description: |
+        Fetches recent manga updates from the MangaDex feed, with caching.
+        Will update once an hour and return the 100 most recent entries.
+        It accepts no parameters.
+        See [the MangaDex Manga documentation](https://api.mangadex.org/docs/redoc.html#tag/Manga/operation/get-search-manga)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ./app:/app
       - node_modules:/app/node_modules
+      - ${GCLOUD_CONFIG_PATH:-~/.config/gcloud}:/root/.config/gcloud
     command: npm run dev -- --host --port 5173
     ports:
       - "5173:5173"
@@ -25,6 +26,7 @@ services:
       - nginx
     environment:
       - VITE_STATIC_HOST=http://nginx:4000
+      - VITE_CACHE_BUCKET=manga-recsys-cache
   redoc:
     image: redocly/redoc
     restart: always

--- a/notebooks/20230105-00-word2vec-persist.ipynb
+++ b/notebooks/20230105-00-word2vec-persist.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%load_ext lab_black\n",
+    "from pyspark.sql import functions as F, Window\n",
+    "from manga_recsys.spark import get_spark\n",
+    "\n",
+    "spark = get_spark()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<gensim.models.word2vec.Word2Vec at 0x23506385fc0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from manga_recsys.models.manga import generate_manga_tags_word2vec\n",
+    "\n",
+    "manga_info = spark.read.parquet(\n",
+    "    \"../data/processed/2022-12-17-metadata-listing/manga_info.parquet\"\n",
+    ")\n",
+    "\n",
+    "manga_tags, model = generate_manga_tags_word2vec(\n",
+    "    manga_info, vector_col=\"w2v\", return_model=True\n",
+    ")\n",
+    "\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "26229"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# convert keyed vector in wv to a dataframe\n",
+    "# use key_to_index and wv.vectors\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "df = pd.DataFrame({}, index=model.wv.key_to_index)\n",
+    "df[\"emb\"] = model.wv.vectors.tolist()\n",
+    "\n",
+    "# save this to the w2v model directory\n",
+    "\n",
+    "path = Path(\n",
+    "    \"../data/processed/2022-12-20-recommendation-manga-tags-word2vec/word2vec.json\"\n",
+    ")\n",
+    "path.write_text(json.dumps(df.to_dict()))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "bca7b2bdba768571c0082ebd75c4aeb7591ff0a55f8644ae03b303997b530c9d"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,6 +40,14 @@ resource "google_storage_bucket" "default" {
   }
 }
 
+// make a non-public bucket that we use for caching static files; we can remove
+// files after a while; we also don't need cors headers
+resource "google_storage_bucket" "cache" {
+  name                        = "${local.repo_name}-cache"
+  location                    = "US"
+  uniform_bucket_level_access = true
+}
+
 resource "google_storage_bucket_iam_member" "default-public" {
   bucket = google_storage_bucket.default.name
   role   = "roles/storage.objectViewer"
@@ -84,6 +92,7 @@ resource "google_cloudbuild_trigger" "github" {
   substitutions = {
     _REGION           = local.region
     _VITE_STATIC_HOST = "https://storage.googleapis.com/${google_storage_bucket.default.name}"
+    _VITE_CACHE_HOST  = google_storage_bucket.cache.name
   }
   filename        = "cloudbuild.yaml"
   service_account = google_service_account.cloudbuild.id


### PR DESCRIPTION
This adds a /manga/feed page for testing out reranking on recent updates.
It takes the word2vec model and computes a personalization vector based on the average vector of each manga vector.
All manga vectors are constructed locally.

The feed comes from the manga listing api, and is paged on demand at most once an hour. 

![image](https://user-images.githubusercontent.com/70861751/210959360-6f58aaac-39bb-4f65-8184-de82a8ee3ab3.png)

This code is kind of awful, so it should probably be refactored at some point.
This took about 5 hours to build.